### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
   # トップ画面
   def index
     # 商品情報が新規投稿順に並ぶように取得
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   # 商品出品画面

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
   # トップ画面
   def index
     # 商品情報が新規投稿順に並ぶように取得
-    @items = Item.all.order('created_at DESC')
+    @items = Item.order('created_at DESC')
   end
 
   # 商品出品画面

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,8 @@ class ItemsController < ApplicationController
 
   # トップ画面
   def index
+    # 商品情報が新規投稿順に並ぶように取得
+    @items = Item.all.order("created_at DESC")
   end
 
   # 商品出品画面

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,7 +1,8 @@
 <li class='list'>
   <%= link_to "#" do %>
   <div class='item-img-content'>
-    <%= image_tag "item-sample.png", class: "item-img" %>
+    <%# 出品画像 %>
+    <%= link_to image_tag(item.image, class: :"item-img" ), "/" %>
 
     <%# 商品が売れていればsold outを表示しましょう %>
     <%# <div class='sold-out'>
@@ -12,10 +13,15 @@
   </div>
   <div class='item-info'>
     <h3 class='item-name'>
-      <%= "商品名" %>
+    <%# 商品名 %>
+      <%= item.name %>
     </h3>
     <div class='item-price'>
-      <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+      <%# 価格 %>
+      <span><%= item.price %>円<br>
+      <%# 配送料負担 %>
+      <%= item.shipping_fee_status.name %></span>
+
       <div class='star-btn'>
         <%= image_tag "star.png", class:"star-icon" %>
         <span class='star-count'>0</span>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,0 +1,26 @@
+<li class='list'>
+  <%= link_to "#" do %>
+  <div class='item-img-content'>
+    <%= image_tag "item-sample.png", class: "item-img" %>
+
+    <%# 商品が売れていればsold outを表示しましょう %>
+    <%# <div class='sold-out'>
+      <span>Sold Out!!</span>
+    </div> %>
+    <%# //商品が売れていればsold outを表示しましょう %>
+
+  </div>
+  <div class='item-info'>
+    <h3 class='item-name'>
+      <%= "商品名" %>
+    </h3>
+    <div class='item-price'>
+      <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+      <div class='star-btn'>
+        <%= image_tag "star.png", class:"star-icon" %>
+        <span class='star-count'>0</span>
+      </div>
+    </div>
+  </div>
+  <% end %>
+</li>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
       <%# 商品一覧の情報確認 %>
-      <% if @items_length %>
+      <% if @items.length != 0 %>
         <%# 商品がある場合 %>
         <%# 部分テンプレートで、商品一覧を表示する %>
         <%= render partial: "item", collection: @items %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,8 +125,31 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-      <%# 部分テンプレートで、商品一覧を表示する %>
-      <%= render partial: "item", collection: @items %>
+      <%# 商品一覧の情報確認 %>
+      <% if @items_length %>
+        <%# 商品がある場合 %>
+        <%# 部分テンプレートで、商品一覧を表示する %>
+        <%= render partial: "item", collection: @items %>
+      <% else %>
+        <%# 商品がない場合のダミー %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
+            </div>
+          </div>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,57 +125,8 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+      <%# 部分テンプレートで、商品一覧を表示する %>
+      <%= render partial: "item", collection: @items %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
#What
商品一覧表示機能を作成

【未実装項目】
・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
　※商品購入機能未実装の為

機能の様子
■商品一覧表示（新規出品順）
https://gyazo.com/838c948b24a65f7fba14de1b89808c5f
■商品一覧表示（ログアウト時）
https://gyazo.com/8eaec5a3b1f0f47789d12eacf62d29a5
■商品一覧表示（商品情報無しの場合）
https://gyazo.com/edb7baa305abcf250d5261d75e558f0a

#Why
商品一覧表示を実装する為