### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,6 +30,8 @@ class ItemsController < ApplicationController
 
   # 商品詳細画面
   def show
+    # 送信されたIDでitemを取得
+    @item = Item.find(params[:id])
   end
 
   # ストロングパラメーター取得

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  # 商品詳細画面
+  def show
+  end
+
   # ストロングパラメーター取得
   private def item_params
     params.require(:item).permit(:name, :info,

--- a/app/models/sales_status.rb
+++ b/app/models/sales_status.rb
@@ -1,11 +1,14 @@
 class SalesStatus < ActiveHash::Base
   include ActiveHash::Associations
-  # 発送までの日数の一覧
+  # 商品の状態の一覧
   self.data = [
     { id: 0, name: '---' },
-    { id: 1, name: '1~2日で発送' },
-    { id: 2, name: '2~3日で発送' },
-    { id: 3, name: '4~7日で発送' }
+    { id: 1, name: '新品、未使用' },
+    { id: 2, name: '未使用に近い' },
+    { id: 3, name: '目立った傷や汚れなし' },
+    { id: 4, name: 'やや傷や汚れあり' },
+    { id: 5, name: '傷や汚れあり' },
+    { id: 6, name: '全体的に状態が悪い' }
   ]
   # items テーブル
   has_many :items

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -1,14 +1,11 @@
 class ScheduledDelivery < ActiveHash::Base
   include ActiveHash::Associations
-  # 商品の状態の一覧
+  # 発送までの日数の一覧
   self.data = [
     { id: 0, name: '---' },
-    { id: 1, name: '新品、未使用' },
-    { id: 2, name: '未使用に近い' },
-    { id: 3, name: '目立った傷や汚れなし' },
-    { id: 4, name: 'やや傷や汚れあり' },
-    { id: 5, name: '傷や汚れあり' },
-    { id: 6, name: '全体的に状態が悪い' }
+    { id: 1, name: '1~2日で発送' },
+    { id: 2, name: '2~3日で発送' },
+    { id: 3, name: '4~7日で発送' }
   ]
   # items テーブル
   has_many :items

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,32 +1,31 @@
 <li class='list'>
-  <%= link_to "#" do %>
-  <div class='item-img-content'>
-    <%# 出品画像 %>
-    <%= link_to image_tag(item.image, class: :"item-img" ), "/" %>
+  <%= link_to item_path(item) do %>
+    <div class='item-img-content'>
+      <%# 出品画像 %>
+      <%= image_tag item.image, class: "item-img" %>
 
-    <%# 商品が売れていればsold outを表示しましょう %>
-    <%# <div class='sold-out'>
-      <span>Sold Out!!</span>
-    </div> %>
-    <%# //商品が売れていればsold outを表示しましょう %>
+      <%# 商品が売れていればsold outを表示しましょう %>
+      <%# <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div> %>
+      <%# //商品が売れていればsold outを表示しましょう %>
+    </div>
+    <div class='item-info'>
+      <h3 class='item-name'>
+      <%# 商品名 %>
+        <%= item.name %>
+      </h3>
+      <div class='item-price'>
+        <%# 価格 %>
+        <span><%= item.price %>円<br>
+        <%# 配送料負担 %>
+        <%= item.shipping_fee_status.name %></span>
 
-  </div>
-  <div class='item-info'>
-    <h3 class='item-name'>
-    <%# 商品名 %>
-      <%= item.name %>
-    </h3>
-    <div class='item-price'>
-      <%# 価格 %>
-      <span><%= item.price %>円<br>
-      <%# 配送料負担 %>
-      <%= item.shipping_fee_status.name %></span>
-
-      <div class='star-btn'>
-        <%= image_tag "star.png", class:"star-icon" %>
-        <span class='star-count'>0</span>
+        <div class='star-btn'>
+          <%= image_tag "star.png", class:"star-icon" %>
+          <span class='star-count'>0</span>
+        </div>
       </div>
     </div>
-  </div>
   <% end %>
 </li>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -80,7 +80,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:scheduled_delivery_id, ShippingFeeStatus.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, ScheduledDelivery.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,18 +27,17 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ログインかつ、商品出品者と同一確認 %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ログインかつ、商品出品者と違う確認 %>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
       <%# 商品説明 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,22 +4,26 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%# 商品名 %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%# 出品画像 %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%# 価格 %>
+        <%= "¥ #{@item.price.to_s(:delimited)}" %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%# 配送料の負担 %>
+        <%= @item.shipping_fee_status.name %>
       </span>
     </div>
 
@@ -37,33 +41,34 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <%# 商品説明 %>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,16 +27,18 @@
       </span>
     </div>
 
-    <%# ログインかつ、商品出品者と同一確認 %>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
+    <%# ログイン確認 %>
+    <% if user_signed_in? %>
+      <%# 商品出品者と同一の場合 %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%# ログインかつ、商品出品者と違う確認 %>
-    <% if user_signed_in? && current_user.id != @item.user_id %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# 商品出品者と違う場合 %>
+      <% else %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">
@@ -106,7 +108,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   # ルートパスの設定
   root to: "items#index"
   # itemsのパス
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :show]
 end


### PR DESCRIPTION
#What
商品詳細表示機能を作成

【未実装項目】
・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
・売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
　※商品購入機能未実装の為

機能の様子
■商品詳細表示（出品者）
https://gyazo.com/f9885e74a1b8107f156c1b6ad81ebe75
■商品詳細表示（出品者以外）
https://gyazo.com/1cbfeefe4c1e26fdd87d478f2d760ba8
■商品詳細表示（ログアウト時）
https://gyazo.com/79ac766be8ff0522ff14e58b815b5262

#Why
商品詳細表示機能を実装する為